### PR TITLE
Drop support for properties of type signed char due to indistinguishabilit…

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -566,6 +566,12 @@ static JSONKeyMapper* globalKeyMapper = nil;
             if ([attributeItems containsObject:@"R"]) {
                 continue; //to next property
             }
+            
+            //check for 32b BOOLs
+            if ([propertyAttributes hasPrefix:@"Tc,"]) {
+                //mask BOOLs as structs so they can have custom converters
+                p.structName = @"BOOL";
+            }
 
             scanner = [NSScanner scannerWithString: propertyAttributes];
 

--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -20,8 +20,8 @@ extern BOOL isNull(id value)
 {
     self = [super init];
     if (self) {
-        _primitivesNames = @{@"f":@"float", @"i":@"int", @"d":@"double", @"l":@"long", @"B":@"BOOL", @"s":@"short",
-                             @"I":@"unsigned int", @"L":@"usigned long", @"q":@"long long", @"Q":@"unsigned long long", @"S":@"unsigned short", @"c":@"char", @"C":@"unsigned char",
+        _primitivesNames = @{@"f":@"float", @"i":@"int", @"d":@"double", @"l":@"long", @"c":@"BOOL", @"s":@"short",
+                             @"I":@"unsigned int", @"L":@"usigned long", @"q":@"long long", @"Q":@"unsigned long long", @"S":@"unsigned short", @"C":@"unsigned char",
                              //and some famous aliases of primitive types
                              // BOOL is now "B" on iOS __LP64 builds
                              @"I":@"NSInteger", @"Q":@"NSUInteger", @"B":@"BOOL",


### PR DESCRIPTION
…y between char and BOOL in some situations. Support for unsigned char is uneffected.